### PR TITLE
chore: refactor nuon dns

### DIFF
--- a/module/outputs.tf
+++ b/module/outputs.tf
@@ -17,11 +17,3 @@ output "ecr" {
 output "nuon_dns" {
   value = module.nuon-aws-eks-sandbox.nuon_dns
 }
-
-output "alb_ingress_controller" {
-  value = module.nuon-aws-eks-sandbox.alb_ingress_controller
-}
-
-output "ingress_nginx" {
-  value = module.nuon-aws-eks-sandbox.ingress_nginx
-}

--- a/nuon_dns.tf
+++ b/nuon_dns.tf
@@ -5,6 +5,7 @@ module "nuon_dns" {
 
   internal_root_domain  = var.internal_root_domain
   public_root_domain    = var.public_root_domain
+  eks_cluster_name      = module.eks.cluster_name
   eks_oidc_provider_arn = module.eks.oidc_provider_arn
   region                = var.region
   vpc_id                = data.aws_vpc.vpc.id
@@ -13,7 +14,5 @@ module "nuon_dns" {
 
   depends_on = [
     module.eks,
-    helm_release.metrics_server,
-    helm_release.alb_ingress_controller
   ]
 }

--- a/nuon_dns/cert-manager-issuer.tf
+++ b/nuon_dns/cert-manager-issuer.tf
@@ -12,7 +12,7 @@ resource "kubectl_manifest" "internal_cluster_issuer" {
     apiVersion = "cert-manager.io/v1"
     kind       = "ClusterIssuer"
     metadata = {
-      namespace = "cert-manager"
+      namespace = local.cert_manager.namespace
       name      = local.cert_manager_issuers.internal_issuer_name
     }
     spec = {
@@ -51,7 +51,7 @@ resource "kubectl_manifest" "public_cluster_issuer" {
     apiVersion = "cert-manager.io/v1"
     kind       = "ClusterIssuer"
     metadata = {
-      namespace = "cert-manager"
+      namespace = local.cert_manager.namespace
       name      = local.cert_manager_issuers.public_issuer_name
     }
     spec = {
@@ -79,4 +79,7 @@ resource "kubectl_manifest" "public_cluster_issuer" {
       }
     }
   })
+  depends_on = [
+    helm_release.cert_manager
+  ]
 }

--- a/nuon_dns/cert-manager.tf
+++ b/nuon_dns/cert-manager.tf
@@ -28,10 +28,10 @@ module "cert_manager_irsa" {
 }
 
 resource "helm_release" "cert_manager" {
-  namespace        = "cert-manager"
+  namespace        = local.cert_manager.namespace
   create_namespace = true
 
-  name       = "cert-manager"
+  name       = local.cert_manager.name
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
   version    = "v1.11.0"

--- a/nuon_dns/external_dns.tf
+++ b/nuon_dns/external_dns.tf
@@ -3,6 +3,7 @@ locals {
   public_domain   = aws_route53_zone.public.name
   external_dns = {
     namespace = "external-dns"
+    name      = "external-dns"
     extra_args = {
       0 = "--publish-internal-services",
       1 = "--zone-id-filter=${aws_route53_zone.internal.id}",
@@ -36,10 +37,10 @@ module "external_dns_irsa" {
 }
 
 resource "helm_release" "external_dns" {
-  namespace        = "external-dns"
+  namespace        = local.external_dns.namespace
   create_namespace = true
 
-  name       = "external-dns"
+  name       = local.external_dns.name
   repository = "https://kubernetes-sigs.github.io/external-dns/"
   chart      = "external-dns"
   version    = "1.12.0"

--- a/nuon_dns/ingress_nginx.tf
+++ b/nuon_dns/ingress_nginx.tf
@@ -1,10 +1,15 @@
-resource "helm_release" "ingress_nginx" {
-  count = local.enable_ingress_nginx ? 1 : 0
+locals {
+  ingress_nginx = {
+    namespace = "ingress-nginx"
+    name      = "ingress-nginx"
+  }
+}
 
-  namespace        = "nginx-ingress"
+resource "helm_release" "ingress_nginx" {
+  namespace        = local.ingress_nginx.namespace
   create_namespace = true
 
-  name       = "ingress-nginx"
+  name       = local.ingress_nginx.name
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
   version    = "4.12.1"
@@ -16,7 +21,6 @@ resource "helm_release" "ingress_nginx" {
   }
 
   depends_on = [
-    module.alb_controller_irsa,
     helm_release.alb_ingress_controller
   ]
 }

--- a/nuon_dns/outputs.tf
+++ b/nuon_dns/outputs.tf
@@ -14,8 +14,54 @@ output "internal_domain" {
   }
 }
 
+output "external_dns" {
+  value = {
+    enabled = true
+    release = {
+      id        = helm_release.external_dns.id
+      namespace = helm_release.external_dns.metadata[0].namespace
+      name      = helm_release.external_dns.metadata[0].name
+      chart     = helm_release.external_dns.metadata[0].chart
+      revision  = helm_release.external_dns.metadata[0].revision
+    }
+  }
+}
+
 output "cert_manager" {
   value = {
     enabled = true
+    release = {
+      id        = helm_release.cert_manager.id
+      namespace = helm_release.cert_manager.metadata[0].namespace
+      name      = helm_release.cert_manager.metadata[0].name
+      chart     = helm_release.cert_manager.metadata[0].chart
+      revision  = helm_release.cert_manager.metadata[0].revision
+    }
+  }
+}
+
+output "ingress_nginx" {
+  value = {
+    enabled = true
+    release = {
+      id        = helm_release.ingress_nginx.id
+      namespace = helm_release.ingress_nginx.metadata[0].namespace
+      name      = helm_release.ingress_nginx.metadata[0].name
+      chart     = helm_release.ingress_nginx.metadata[0].chart
+      revision  = helm_release.ingress_nginx.metadata[0].revision
+    }
+  }
+}
+
+output "alb_ingress_controller" {
+  value = {
+    enabled = true
+    release = {
+      id        = helm_release.alb_ingress_controller.id
+      namespace = helm_release.alb_ingress_controller.metadata[0].namespace
+      name      = helm_release.alb_ingress_controller.metadata[0].name
+      chart     = helm_release.alb_ingress_controller.metadata[0].chart
+      revision  = helm_release.alb_ingress_controller.metadata[0].revision
+    }
   }
 }

--- a/nuon_dns/variables.tf
+++ b/nuon_dns/variables.tf
@@ -1,6 +1,11 @@
+variable "eks_cluster_name" {
+  type        = string
+  description = "The name of the EKS Cluster created in eks.tf"
+}
+
 variable "eks_oidc_provider_arn" {
   type        = string
-  description = "The EKS Cluster OIDC Provider aRN"
+  description = "The EKS Cluster OIDC Provider ARN"
 }
 
 variable "internal_root_domain" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,19 +67,29 @@ output "nuon_dns" {
     enabled         = local.nuon_dns.enabled,
     public_domain   = local.nuon_dns.enabled ? module.nuon_dns[0].public_domain : { zone_id : "", name : "", nameservers : tolist([""]) }
     internal_domain = local.nuon_dns.enabled ? module.nuon_dns[0].internal_domain : { zone_id : "", name : "", nameservers : tolist([""]) }
-  }
-}
-
-output "alb_ingress_controller" {
-  value = {
-    enabled = local.enable_alb_ingress_controller
-    id      = local.enable_alb_ingress_controller ? resource.helm_release.alb_ingress_controller[0].id : ""
-  }
-}
-
-output "ingress_nginx" {
-  value = {
-    enabled = local.enable_ingress_nginx
-    id      = local.enable_ingress_nginx ? resource.helm_release.ingress_nginx[0].id : ""
+    alb_ingress_controller = {
+      enabled  = local.nuon_dns.enabled
+      id       = local.nuon_dns.enabled ? module.nuon_dns[0].alb_ingress_controller.release.id : ""
+      chart    = local.nuon_dns.enabled ? module.nuon_dns[0].alb_ingress_controller.release.chart : ""
+      revision = local.nuon_dns.enabled ? module.nuon_dns[0].alb_ingress_controller.release.revision : ""
+    }
+    external_dns = {
+      enabled  = local.nuon_dns.enabled
+      id       = local.nuon_dns.enabled ? module.nuon_dns[0].external_dns.release.id : ""
+      chart    = local.nuon_dns.enabled ? module.nuon_dns[0].external_dns.release.chart : ""
+      revision = local.nuon_dns.enabled ? module.nuon_dns[0].external_dns.release.revision : ""
+    }
+    cert_manager = {
+      enabled  = local.nuon_dns.enabled
+      id       = local.nuon_dns.enabled ? module.nuon_dns[0].cert_manager.release.id : ""
+      chart    = local.nuon_dns.enabled ? module.nuon_dns[0].cert_manager.release.chart : ""
+      revision = local.nuon_dns.enabled ? module.nuon_dns[0].cert_manager.release.revision : ""
+    }
+    ingress_nginx = {
+      enabled  = local.nuon_dns.enabled
+      id       = local.nuon_dns.enabled ? module.nuon_dns[0].ingress_nginx.release.id : ""
+      chart    = local.nuon_dns.enabled ? module.nuon_dns[0].ingress_nginx.release.chart : ""
+      revision = local.nuon_dns.enabled ? module.nuon_dns[0].ingress_nginx.release.revision : ""
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,8 @@
 locals {
-  enable_alb_ingress_controller = contains(["1", "true"], var.enable_alb_ingress_controller)
-  enable_ingress_nginx          = contains(["1", "true"], var.enable_ingress_nginx) && local.enable_alb_ingress_controller
   # nuon dns
   enable_nuon_dns = contains(["1", "true"], var.enable_nuon_dns)
   nuon_dns = {
-    enabled              = local.enable_nuon_dns && local.enable_alb_ingress_controller
+    enabled              = local.enable_nuon_dns
     internal_root_domain = var.internal_root_domain
     public_root_domain   = var.public_root_domain
   }


### PR DESCRIPTION
### Description

Refactor `nuon_dns` module. 
1. move all `helm_release`s used by `nuon_dns` into the `nuon_dns` module. 
2. update the `nuon_dns` outputs to emit data bout each helm release. 