### PR TITLE
chore: maintenance role needs * on namespaces

### DIFF
--- a/values/k8s/maintenance_role.yaml
+++ b/values/k8s/maintenance_role.yaml
@@ -289,9 +289,11 @@ rules:
   resources:
   - namespaces
   verbs:
-  - get
-  - list
-  - watch
+  - "*" # over written with * so helm can do its thing
+  # default
+  # - get
+  # - list
+  # - watch
 - apiGroups:
   - discovery.k8s.io
   resources:


### PR DESCRIPTION
this makes the mantenance role RBAC perms equivalent to
`AmazonEKSEditPolicy` minus `get`, `list`, `watch` secrets and plus `*`
on namespaces in all namespaces.
