### PR TITLE
fd/providers/use exec in helm and kubectl provider

### DIFF
--- a/ebs_csi.tf
+++ b/ebs_csi.tf
@@ -56,6 +56,7 @@ resource "helm_release" "ebs_csi" {
 
   depends_on = [
     module.ebs_csi_irsa,
-    module.eks
+    module.eks,
+    resource.null_resource.set_kubeconfig
   ]
 }

--- a/kyverno.tf
+++ b/kyverno.tf
@@ -38,7 +38,7 @@ resource "kubectl_manifest" "default_policies" {
 }
 
 resource "kubectl_manifest" "vendor_policies" {
-  for_each = fileset("${var.kyverno_policy_dir}", "*.yaml")
+  for_each = fileset(var.kyverno_policy_dir, "*.yaml")
 
   yaml_body = file("${var.kyverno_policy_dir}/${each.key}")
 

--- a/nr.tf
+++ b/nr.tf
@@ -1,0 +1,6 @@
+resource "null_resource" "set_kubeconfig" {
+  provisioner "local-exec" {
+    command = "aws eks --region ${var.region} update-kubeconfig --name ${module.eks.cluster_name}"
+  }
+  depends_on = [module.eks]
+}

--- a/nuon_dns.tf
+++ b/nuon_dns.tf
@@ -14,5 +14,6 @@ module "nuon_dns" {
 
   depends_on = [
     module.eks,
+    resource.null_resource.set_kubeconfig,
   ]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,62 @@
+locals {
+  k8s_exec = [{
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws-iam-authenticator"
+    # This requires the aws iam authenticator to be installed locally where Terraform is executed
+    args = ["token", "-i", module.eks.cluster_name]
+  }]
+}
+
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = local.tags
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  dynamic "exec" {
+    for_each = local.k8s_exec
+    content {
+      api_version = exec.value.api_version
+      command     = exec.value.command
+      args        = exec.value.args
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+    dynamic "exec" {
+      for_each = local.k8s_exec
+      content {
+        api_version = exec.value.api_version
+        command     = exec.value.command
+        args        = exec.value.args
+      }
+    }
+  }
+}
+
+provider "kubectl" {
+  apply_retry_count      = 5
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  load_config_file       = false
+
+  dynamic "exec" {
+    for_each = local.k8s_exec
+    content {
+      api_version = exec.value.api_version
+      command     = exec.value.command
+      args        = exec.value.args
+    }
+  }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -11,7 +11,7 @@ provider "aws" {
   region = var.region
 
   default_tags {
-    tags = local.tags
+    tags = local.default_tags
   }
 }
 

--- a/rbac.tf
+++ b/rbac.tf
@@ -9,7 +9,11 @@ locals {
 }
 
 resource "kubectl_manifest" "maintenance" {
-  for_each   = toset([local.groups.maintenance.role, local.groups.maintenance.role_binding])
-  yaml_body  = file(each.value)
-  depends_on = [module.eks]
+  for_each  = toset([local.groups.maintenance.role, local.groups.maintenance.role_binding])
+  yaml_body = file(each.value)
+
+  depends_on = [
+    module.eks,
+    resource.null_resource.set_kubeconfig
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,13 +8,13 @@ locals {
   }
 
   # tags for all of the resources
+  default_tags = merge(var.tags, {
+    "install.nuon.co/id"   = var.nuon_id
+    "sandbox.nuon.co/name" = "aws-eks"
+  })
   tags = merge(
-    var.tags,
-    {
-      "install.nuon.co/id"  = var.nuon_id
-      "sanbox.nuon.co/name" = "aws-eks"
-    },
     var.additional_tags,
+    local.default_tags,
   )
 
   roles = {


### PR DESCRIPTION
- **chore: providers: helm and kubectl need dynamic creds**
- **chore: update use of tags**
- **chore: lint**
