### PR TITLE
chore: give the runner access explicitly via sg

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -68,6 +68,14 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+data "aws_security_groups" "runner" {
+  tags = {
+    "network.nuon.co/domain" = "runner"
+    "install.nuon.co/id"     = var.nuon_id
+  }
+}
+
+
 locals {
   subnets = {
     private = {

--- a/eks.tf
+++ b/eks.tf
@@ -87,3 +87,16 @@ module "eks" {
 
   tags = local.tags
 }
+
+# TODO: revisit this access method
+resource "aws_security_group_rule" "runner_cluster_access" {
+  type                     = "ingress"
+  description              = "Allow ingress traffic from runner."
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  security_group_id        = module.eks.cluster_security_group_id
+  source_security_group_id = data.aws_security_groups.runner.ids[0] # make this less brittle
+
+  depends_on = [module.eks]
+}


### PR DESCRIPTION
this requires the runner subnet's security group to have the
`network.nuon.co/domain = runner` tag. this is upstreamed in the ctl
plane but won't work for previous deploys.
