### PR TITLE
feat: additional irsa

### DIFF
--- a/additional_irsa.tf
+++ b/additional_irsa.tf
@@ -1,0 +1,24 @@
+module "additional_irsa" {
+  for_each = {
+    for index, ai in var.additional_irsas :
+    ai.role_name => ai
+  }
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+
+  role_name             = each.value.role_name
+  attach_ebs_csi_policy = false
+
+  oidc_providers = {
+    k8s = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["${each.value.namespace}:${each.value.service_account}"]
+    }
+  }
+
+  tags = merge(local.tags, {
+    "sandbox.nuon.co/module" = "additional_irsa"
+    "sandbox.nuon.co/source" = "user-defined"
+  })
+  depends_on = [module.eks]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -102,3 +102,7 @@ output "namespaces" {
   value       = [for km in kubectl_manifest.namespaces : km.name]
   description = "A list of namespaces that were created by this module."
 }
+
+output "additional_irsa" {
+  value = { for ai in module.additional_irsa : ai.iam_role_name => ai }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -172,10 +172,23 @@ variable "maintenance_cluster_role_rules_override" {
 }
 
 
+# kyverno policies
 variable "kyverno_policy_dir" {
   type        = string
   description = "Path to a directory with kyverno policy manifests."
   default     = "./kyverno-policies"
+}
+
+# additional IRSAs
+variable "additional_irsas" {
+  # name and serviceaccount are combined in oids.k8s.namespace_service_accounts as ["${var.namespace}:${serviceaccount}"]
+  type = list(object({
+    role_name       = string,
+    namespace       = string,
+    service_account = string,
+  }))
+  description = "List of additional IRSA accounts to create."
+  default     = []
 }
 
 #


### PR DESCRIPTION
it is often necessary to have IRSA roles in hand for services but for maintenance role to not have enough permissions to create them. in these cases, they should be created by the provision role.