### PR TITLE
tag subnets with elb roles so LoadBalancer services provision

### DIFF
--- a/subnet_tags/main.tf
+++ b/subnet_tags/main.tf
@@ -12,3 +12,21 @@ resource "aws_ec2_tag" "public_subnets_cluster_tags" {
   key         = "kubernetes.io/cluster/${var.eks_cluster_name}"
   value       = "shared"
 }
+
+# ELB role tags: required for the AWS cloud-controller-manager to auto-discover
+# subnets when placing load balancers for Service type=LoadBalancer (e.g. the
+# ingress-nginx controller). Without these the LB never provisions and helm
+# waits forever on the pending Service.
+resource "aws_ec2_tag" "public_subnets_elb_role" {
+  for_each    = toset(var.public_subnet_ids)
+  resource_id = each.value
+  key         = "kubernetes.io/role/elb"
+  value       = "1"
+}
+
+resource "aws_ec2_tag" "private_subnets_internal_elb_role" {
+  for_each    = toset(var.private_subnet_ids)
+  resource_id = each.value
+  key         = "kubernetes.io/role/internal-elb"
+  value       = "1"
+}


### PR DESCRIPTION
subnet_tags only set kubernetes.io/cluster; missing kubernetes.io/role/elb (public) and role/internal-elb (private). without them the cloud-controller-manager can't place the ELB for the ingress-nginx LoadBalancer service, so helm wait hangs 'Still creating' until timeout. adds the role tags.